### PR TITLE
Updated link to javadoc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Atlantis library will aid you in mocking the Internet for your Android app. It offers means of delivering custom tailored responses to network requests made by your app, without forcing you to do massive changes to your code.
 
-The "News" section in [the Wiki](https://github.com/echsylon/atlantis/wiki) holds a rough change list. You can also get a quick-n-dirty introduction to Atlantis in the "How to" section, or have a look at the [JSON configuration reference](https://github.com/echsylon/atlantis/wiki/JSON-Configuration-File) and the [JavaDoc](http://echsylon.github.io/atlantis/javadoc/index.html) documentation for more technically detailed information in the "Reference" section.
+The "News" section in [the Wiki](https://github.com/echsylon/atlantis/wiki) holds a rough change list. You can also get a quick-n-dirty introduction to Atlantis in the "How to" section, or have a look at the [JSON configuration reference](https://github.com/echsylon/atlantis/wiki/JSON-Configuration-File) and the [JavaDoc](https://echsylon.github.io/atlantis/index.html) documentation for more technically detailed information in the "Reference" section.
 
 If you want even more love, you could check out the [Atlantis Extra](https://github.com/echsylon/atlantis-extra/wiki) integration layer as well. You can also find the source code to a demo app, using the said integration layer, [here](https://github.com/echsylon/atlantis-demo).
 


### PR DESCRIPTION
The link to the javadoc in README was outdated. I took this one from the wiki.